### PR TITLE
Update composer.json for PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,13 @@
   "name": "magento/composer",
   "description": "Magento composer library helps to instantiate Composer application and run composer commands.",
   "type": "library",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": [
     "OSL-3.0",
     "AFL-3.0"
   ],
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0",
+    "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0",
     "composer/composer": "1.0.0-beta1",
     "symfony/console": "~2.3, !=2.7.0"
   },


### PR DESCRIPTION
In order to support PHP 7.1, we need to add 7.1 as supported version in our libraries.